### PR TITLE
Remove auto open of the browser on gulp serve

### DIFF
--- a/generators/app/conf.js
+++ b/generators/app/conf.js
@@ -3,7 +3,8 @@ const lit = require('fountain-generator').lit;
 module.exports = function browsersyncConf(props) {
   const conf = {
     server: {
-      baseDir: []
+      baseDir: [],
+      browser: []
     }
   };
 


### PR DESCRIPTION
It's a real design choice here. I just don't want anymore that my browser take focus after the gulp serve. Often I run serve several times and get multiple tabs opened.
