### PR TITLE
[WIP] Remove browsersync-spa is no router is used

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -6,11 +6,12 @@ module.exports = fountain.Base.extend({
     package() {
       const pkg = {
         devDependencies: {
-          'browser-sync': '^2.9.11',
-          'browser-sync-spa': '^1.0.3'
+          'browser-sync': '^2.9.11'
         }
       };
-
+      if (this.options.router !== 'none') {
+        pkg.devDependencies['browser-sync-spa'] = '^1.0.3';
+      }
       this.mergeJson('package.json', pkg);
     },
 
@@ -34,7 +35,7 @@ module.exports = fountain.Base.extend({
     this.copyTemplate(
       'gulp_tasks/browsersync.js',
       'gulp_tasks/browsersync.js',
-      conf(this.options)
+      Object.assign(conf(this.options), {router: this.options.router})
     );
   }
 });

--- a/generators/app/templates/gulp_tasks/browsersync.js
+++ b/generators/app/templates/gulp_tasks/browsersync.js
@@ -1,12 +1,16 @@
 const gulp = require('gulp');
 const browserSync = require('browser-sync');
+<% if (router !== 'none') { -%>
 const spa = require('browser-sync-spa');
+<% } -%>
 
 const browserSyncConf = require('../conf/browsersync.conf');
 const browserSyncDistConf = require('../conf/browsersync-dist.conf');
 
+<% if (router !== 'none') { -%>
 browserSync.use(spa());
 
+<% } -%>
 gulp.task('browsersync', browserSyncServe);
 gulp.task('browsersync:dist', browserSyncDist);
 


### PR DESCRIPTION
When using SystemJS with no router and getting to `localhost/` I have `Cannot GET /`. But when I browser `localhost/toto` or any other fake route, it works. 
When having a router, there is no problem. The easiest workaround I have is to disable `browsersync-spa` when not using a router. 
