### PR TITLE
Set src dir before .tmp to fix index.html conflicts with SystemJS

### DIFF
--- a/generators/app/conf.js
+++ b/generators/app/conf.js
@@ -12,7 +12,11 @@ module.exports = function browsersyncConf(templateVars) {
     conf.server.baseDir.push(lit`conf.paths.dist`);
   } else {
     conf.server.baseDir.push(lit`conf.paths.tmp`);
-    conf.server.baseDir.push(lit`conf.paths.src`);
+    if (templateVars.modules === 'systemjs') {
+      conf.server.baseDir.unshift(lit`conf.paths.src`);
+    } else {
+      conf.server.baseDir.push(lit`conf.paths.src`);
+    }
     if (templateVars.modules === 'inject') {
       conf.server.routes = {
         '/bower_components': 'bower_components'

--- a/test/app/index/conf.js
+++ b/test/app/index/conf.js
@@ -37,7 +37,7 @@ test(`browsersyncConf when modules is 'systemjs'`, t => {
   const templateVars = {modules: 'systemjs'};
   const expected = {
     server: {
-      baseDir: ['lit>>conf.paths.tmp<<lit', 'lit>>conf.paths.src<<lit'],
+      baseDir: ['lit>>conf.paths.src<<lit', 'lit>>conf.paths.tmp<<lit'],
       routes: {
         '/jspm_packages': 'jspm_packages',
         '/jspm.config.js': 'jspm.config.js',


### PR DESCRIPTION
This fixes a conflict happening with SystemJS. When running `gulp serve:dist`, `index.html` is copied in `.tmp` https://github.com/FountainJS/generator-fountain-systemjs/blob/master/generators/app/templates/gulp_tasks/systemjs.js#L78.
If you run `gulp serve` then, browsersync was serving `.tmp/index.html` instead of `src/index.html`.
